### PR TITLE
New Game Glitch support

### DIFF
--- a/Refunct/Refunct.asl
+++ b/Refunct/Refunct.asl
@@ -20,12 +20,12 @@ split
 
 reset
 {
-    return current.resets > old.resets && current.level == 0;
+    return current.resets > old.resets;
 }
 
 gameTime
 {
-    if (current.level == 31 && current.startPartialSeconds >= 0)
+    if (current.endSeconds > current.startSeconds)
     {
         return TimeSpan.FromSeconds(
             Convert.ToDouble(current.endSeconds - current.startSeconds) +


### PR DESCRIPTION
Update the autosplitter to automatically reset whenever the reset counter increases, and update game time whenever the end time is more than the start time (i.e. the difference would be the game time)

Note that for New Game Glitch runs you would need to have 1 less split since you only press 30 sets of buttons.