### PR TITLE
Correct pointer path

### DIFF
--- a/Refunct/Refunct.asl
+++ b/Refunct/Refunct.asl
@@ -1,11 +1,11 @@
 state("Refunct-Win32-Shipping")
 {
-    int   level               : 0x1FB7378, 0x44, 0xAC;
-    int   resets              : 0x1FB7378, 0x44, 0xB0;
-    int   startSeconds        : 0x1FB7378, 0x44, 0xB4;
-    float startPartialSeconds : 0x1FB7378, 0x44, 0xB8;
-    int   endSeconds          : 0x1FB7378, 0x44, 0xBC;
-    float endPartialSeconds   : 0x1FB7378, 0x44, 0xC0;
+    int   level               : 0x1FB896C, 0xC0, 0xAC;
+    int   resets              : 0x1FB896C, 0xC0, 0xB0;
+    int   startSeconds        : 0x1FB896C, 0xC0, 0xB4;
+    float startPartialSeconds : 0x1FB896C, 0xC0, 0xB8;
+    int   endSeconds          : 0x1FB896C, 0xC0, 0xBC;
+    float endPartialSeconds   : 0x1FB896C, 0xC0, 0xC0;
 }
 
 start


### PR DESCRIPTION
The old pointer path points to a `level` variable in-memory, which updates about half a second after the button was pressed. Moreover, the other offsets for the final IGT used in the autosplitter to set the final time is not available for the old pointer path.
This should now update to the correct pointer path.

Works for 2/2 so far.