### PR TITLE
actually take reset setting into account

### DIFF
--- a/Refunct/Refunct.asl
+++ b/Refunct/Refunct.asl
@@ -64,6 +64,11 @@ split
 	return current.resets != old.resets;
 }
 
+reset
+{
+	return false;
+}
+
 gameTime
 {
 	if (current.endSeconds > current.startSeconds)


### PR DESCRIPTION
Without a reset { } block that contains "working" code, the reset setting cannot be accessed. There is a reason why I used my solution, but I do like this one better.