### PR TITLE
revert to 31 splits & performance improvements

### DIFF
--- a/Refunct/README.md
+++ b/Refunct/README.md
@@ -1,22 +1,12 @@
 # Refunct Autosplitter
-Readme by @firestack and @batedurgonnadie
+(Readme by firestack, BatedUrGonnaDie, Ero)
 ## Info
-Splitter tracks buttons hit.  Will start automatically on new game
-and end on the last button.  Will reset the timer on new game selection as well.
-Sample splits are included in this folder as well.
+Starts and resets the timer on every new game. Splits can be selected in the settings, individual buttons and cubes available.
+Sample splits are included.
 
 ## Instructions
 ### Easiest (will update automatically)
-- Start LiveSplit
-- Start Refunct
-- In LiveSplit, select the game "Refunct"
-- Enable autosplitter for selected game
-
-### Manually Downloading (will not update automatically)
-- Start LiveSplit
-- Start Refunct
-- In layout, add autosplitter and point to .asl file you downloaded from here
-
-After completing a run, the autosplitter cannot reset the splits if you have beaten best times.
-Those need to be saved manually before the splitter will continue functioning.
-This is a limitation of LiveSplit.
+* open your split file (any category) and Right Click LiveSplit 🡆 Edit Splits...
+* make sure the game name is set to "Refunct"
+* above your splits, an "Activate" button will appear, which you need to click
+* set LiveSplit to compare against Game Time (Right Click LiveSplit 🡆 Compare Against 🡆 Game Time)

--- a/Refunct/Refunct.asl
+++ b/Refunct/Refunct.asl
@@ -1,5 +1,4 @@
-state("Refunct-Win32-Shipping")
-{
+state("Refunct-Win32-Shipping") {
 	int   cubes               : 0x1FBF9EC, 0xC0, 0xA4;
 	int   buttons             : 0x1FBF9EC, 0xC0, 0xA8;
 	int   resets              : 0x1FBF9EC, 0xC0, 0xAC;
@@ -9,71 +8,65 @@ state("Refunct-Win32-Shipping")
 	float endPartialSeconds   : 0x1FBF9EC, 0xC0, 0xBC;
 }
 
-startup
-{
-	timer.CurrentTimingMethod = TimingMethod.GameTime;
-	vars.timerModel = new TimerModel { CurrentState = timer };
-	settings.Add("buttons", true, "Split on buttons");
-	for (var index = 1; index <= 37; ++index)
-		settings.Add(index.ToString(), true, "Button " + index.ToString(), "buttons");
+startup {
+	var eB =new Dictionary<int, int> {
+		{7, 2},
+		{10, 2},
+		{18, 2},
+		{26, 3},
+		{28, 2}
+	};
 
-	settings.Add("cubes", false, "Split on cubes");
-	for (var index = 1; index <= 18; ++index)
-		settings.Add("c" + index.ToString(), true, "Cube " + index.ToString(), "cubes");
-}
+	settings.Add("Split on buttons:");
+	settings.Add("Split on cubes:");
 
-init
-{
-	vars.buttons = 0;
-	vars.cubes = 0;
-}
-
-update
-{
-	if (current.resets != old.resets)
-	{
-		vars.buttons = current.buttons;
-		vars.cubes = current.cubes;
-		if (current.buttons == 0 && settings.ResetEnabled)
-			vars.timerModel.Reset();
+	for (int i = 1, bN = 1; i <= 31; ++i, ++bN) {
+		if (eB.ContainsKey(i)) {
+			for (int j = 1; j <= eB[i]; ++j) {
+				settings.Add("b" + bN, j == eB[i] ? true : false, "Button " + i + "-" + j, "Split on buttons:");
+				settings.SetToolTip("b" + bN, (j == 1 ? "First" : j == 2 ? "Second" : "Third") + " button of " + i);
+				if (j < eB[i]) ++bN;
+			}
+		} else {
+			settings.Add("b" + bN, true, "Button " + i, "Split on buttons:");
+		}
 	}
+
+	for (int i = 1; i <= 18; ++i) {
+		string iS = i.ToString();
+		settings.Add("c" + iS, false, "Cube " + iS, "Split on cubes:");
+	}
+
+	vars.buttons = 0;
 }
 
-start
-{
-	if (current.resets != old.resets)
-	{
+start {
+	if (old.resets < current.resets) {
 		vars.buttons = current.buttons;
-		vars.cubes = current.cubes;
 		return true;
 	}
 }
 
-split
-{
-	if (current.buttons > vars.buttons)
-	{
+split {
+	if (old.resets < current.resets && current.buttons != 0) vars.buttons = 0;
+
+	if (current.buttons > vars.buttons) {
 		++vars.buttons;
-		return settings[vars.buttons.ToString()];
+		return settings["b" + vars.buttons.ToString()];
 	}
-	if (current.cubes > vars.cubes)
-	{
-		++vars.cubes;
-		return settings["c" + vars.cubes.ToString()];
-	}
-	return current.resets != old.resets && current.buttons > 0;
+
+	if (old.cubes < current.cubes)
+		return settings["c" + current.cubes.ToString()];
 }
 
-reset
-{
-	return false;
+reset {
+	return old.resets < current.resets && current.buttons == 0;
 }
 
-gameTime
-{
-	if (current.endSeconds > current.startSeconds)
-		return TimeSpan.FromSeconds(
-			Convert.ToDouble(current.endSeconds - current.startSeconds) +
-			Convert.ToDouble(current.endPartialSeconds - current.startPartialSeconds)
-		);
+gameTime {
+	if (current.endSeconds > current.startSeconds) {
+		float s = (float)current.endSeconds - current.startSeconds;
+		float ms = current.endPartialSeconds - current.startPartialSeconds;
+		return TimeSpan.FromSeconds(s + ms);
+	}
 }

--- a/Refunct/Refunct.asl
+++ b/Refunct/Refunct.asl
@@ -20,22 +20,18 @@ startup {
 	settings.Add("Split on buttons:");
 	settings.Add("Split on cubes:");
 
-	for (int i = 1, bN = 1; i <= 31; ++i, ++bN) {
-		if (eB.ContainsKey(i)) {
+	for (int i = 1, bN = 1; i <= 31; ++i, ++bN)
+		if (eB.ContainsKey(i))
 			for (int j = 1; j <= eB[i]; ++j) {
 				settings.Add("b" + bN, j == eB[i] ? true : false, "Button " + i + "-" + j, "Split on buttons:");
 				settings.SetToolTip("b" + bN, (j == 1 ? "First" : j == 2 ? "Second" : "Third") + " button of " + i);
 				if (j < eB[i]) ++bN;
 			}
-		} else {
+		else
 			settings.Add("b" + bN, true, "Button " + i, "Split on buttons:");
-		}
-	}
 
-	for (int i = 1; i <= 18; ++i) {
-		string iS = i.ToString();
-		settings.Add("c" + iS, false, "Cube " + iS, "Split on cubes:");
-	}
+	for (int i = 1; i <= 18; ++i)
+		settings.Add("c" + i, false, "Cube " + i, "Split on cubes:");
 
 	vars.buttons = 0;
 }

--- a/Refunct/Refunct.asl
+++ b/Refunct/Refunct.asl
@@ -9,7 +9,7 @@ state("Refunct-Win32-Shipping") {
 }
 
 startup {
-	var eB =new Dictionary<int, int> {
+	var eB = new Dictionary<int, int> {
 		{7, 2},
 		{10, 2},
 		{18, 2},
@@ -65,7 +65,7 @@ reset {
 
 gameTime {
 	if (current.endSeconds > current.startSeconds) {
-		float s = (float)current.endSeconds - current.startSeconds;
+		float s = (float)(current.endSeconds - current.startSeconds);
 		float ms = current.endPartialSeconds - current.startPartialSeconds;
 		return TimeSpan.FromSeconds(s + ms);
 	}


### PR DESCRIPTION
We all hate the confusion of the 31 vs 37 split formats, one being used by runners for years and the other being used by new waves of runners. It annoys everyone greatly and users of one don't know what the other number means sometimes. We just want to go back.

Also I just made the code a bit better. Pretty sure it works for all categories (tested on normal, NGG, randomizer).