### PR TITLE
fixed slight mishap for NGG splits

### DIFF
--- a/Refunct/Refunct.asl
+++ b/Refunct/Refunct.asl
@@ -51,10 +51,10 @@ startup
 
 update
 {
-	if (old.resets < current.resets && current.buttons == 0)
+	if (old.resets < current.resets)
 	{
 		vars.buttons = 0;
-		if (settings.ResetEnabled)
+		if (current.buttons == 0 && settings.ResetEnabled)
 			vars.timerModel.Reset();
 	}
 }


### PR DESCRIPTION
I absolutely swear I looked for this when I was working on it originally, and 100% fixed it. I suppose some of the moving around to re-add the QoL features messed things up.

Somebody has been saying that 16 does not split during an NGG run. I haven't been able to replicate this.